### PR TITLE
アプリからアクセスするとJavaScriptの機能が機能しない (#2)

### DIFF
--- a/app/src/main/java/jp/ne/t_yankees/MainActivity.java
+++ b/app/src/main/java/jp/ne/t_yankees/MainActivity.java
@@ -61,7 +61,7 @@ public class MainActivity extends AppCompatActivity {
     public static final String EXTRA_POST_DATA = "jp.ne.t_yankees.POST_DATA";
     private static final int REQUEST_CODE_SETTING = 1;
 
-    private final String URL_HP_ROOT = "http://t-yankees.sakura.ne.jp/";
+    private final String URL_HP_ROOT = "https://t-yankees.sakura.ne.jp/";
     private final String WEBSB_CAL = URL_HP_ROOT + "websb3/s-calendar.cgi?";  //スケジュール一覧
     private final String WEBSB_BOARD = URL_HP_ROOT + "websb3/s-webbbs.cgi?";  //メンバー専用掲示板
     private final String WEBSB_SCORE = URL_HP_ROOT + "websb3/s-team.cgi?";  //勝敗結果


### PR DESCRIPTION
アプリからHPにアクセスするときに http://でアクセスしていたため
CORSの問題が発生し、Chrome系のブラウザ（アプリの WebViewも々）で
JavaScriptが動作していなかった。

今回の修正により以下が直る。
- スケジュールの一覧で登録状態(緑／赤)が表示されない問題
- アプリからメンバー用ページ > 個人成績・チーム成績詳細 を見た時表示されない問題